### PR TITLE
Scaffold backend stakeholders lifecycle

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/referral_tracker

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname
+  },
+  env: {
+    node: true,
+    es2021: true
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  ignorePatterns: ['dist', 'node_modules'],
+  rules: {
+    'no-console': ['warn', { allow: ['error'] }]
+  }
+};

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: './tsconfig.json'
+    }
+  }
+};
+
+export default config;

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -1,0 +1,98 @@
+CREATE TABLE IF NOT EXISTS roles (
+  id SERIAL PRIMARY KEY,
+  key TEXT NOT NULL UNIQUE,
+  label TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+  id SERIAL PRIMARY KEY,
+  key TEXT NOT NULL UNIQUE,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  permission_id INTEGER NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+  PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  email TEXT NOT NULL,
+  name TEXT NOT NULL,
+  org_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  scope_program_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, role_id, scope_program_id)
+);
+
+CREATE TABLE IF NOT EXISTS stakeholders (
+  id UUID PRIMARY KEY,
+  type TEXT NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  owner_id UUID REFERENCES users(id),
+  org_id UUID,
+  meta JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stakeholders_status ON stakeholders(status);
+CREATE INDEX IF NOT EXISTS idx_stakeholders_org ON stakeholders(org_id);
+
+CREATE TABLE IF NOT EXISTS stakeholder_members (
+  stakeholder_id UUID NOT NULL REFERENCES stakeholders(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (stakeholder_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id BIGSERIAL PRIMARY KEY,
+  actor_id UUID,
+  action TEXT NOT NULL,
+  entity TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  meta JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_entity ON audit_log(entity, entity_id);
+
+INSERT INTO roles (key, label)
+VALUES
+  ('admin', 'Administrator'),
+  ('manager', 'Manager'),
+  ('contributor', 'Contributor'),
+  ('viewer', 'Viewer')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO permissions (key, description)
+VALUES
+  ('user:manage', 'Manage users and roles'),
+  ('stakeholder:create', 'Create stakeholders'),
+  ('stakeholder:update_status', 'Update stakeholder status'),
+  ('stakeholder:view', 'View stakeholder data'),
+  ('audit:view', 'View audit log')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (
+  (r.key = 'admin' AND TRUE) OR
+  (r.key = 'manager' AND p.key IN ('stakeholder:create', 'stakeholder:update_status', 'stakeholder:view', 'audit:view')) OR
+  (r.key = 'contributor' AND p.key IN ('stakeholder:create', 'stakeholder:update_status', 'stakeholder:view')) OR
+  (r.key = 'viewer' AND p.key = 'stakeholder:view')
+)
+ON CONFLICT DO NOTHING;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "referral-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node --esm src/server.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "tsc --noEmit",
+    "format": "prettier --write .",
+    "test": "jest --runInBand",
+    "migrate": "ts-node --esm src/db/migrate.ts"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "pg": "^8.11.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "pg-mem": "^3.0.5",
+    "prettier": "^3.2.5",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,37 @@
+import cors from 'cors';
+import express from 'express';
+import { authenticate } from './auth/authenticate.js';
+import { AuditService } from './audit/service.js';
+import type { DBClient } from './db/types.js';
+import { errorHandler } from './middleware/error-handler.js';
+import { createStakeholderRouter } from './modules/stakeholders/router.js';
+import { StakeholderService } from './modules/stakeholders/service.js';
+
+export interface AppDependencies {
+  db: DBClient;
+}
+
+export function createApp(deps: AppDependencies) {
+  const app = express();
+  const auditService = new AuditService(deps.db);
+  const stakeholderService = new StakeholderService(deps.db, auditService);
+
+  app.use(
+    cors({
+      origin: true,
+      credentials: true
+    })
+  );
+  app.use(express.json({ limit: '1mb' }));
+  app.use(authenticate());
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/api/stakeholders', createStakeholderRouter({ stakeholderService }));
+
+  app.use(errorHandler);
+
+  return app;
+}

--- a/backend/src/audit/service.ts
+++ b/backend/src/audit/service.ts
@@ -1,0 +1,21 @@
+import type { DBClient } from '../db/types.js';
+
+export interface AuditLogInput {
+  actorId: string;
+  action: string;
+  entity: string;
+  entityId: string;
+  meta?: Record<string, unknown>;
+}
+
+export class AuditService {
+  constructor(private readonly db: DBClient) {}
+
+  async log(entry: AuditLogInput): Promise<void> {
+    await this.db.query(
+      `INSERT INTO audit_log (actor_id, action, entity, entity_id, meta)
+       VALUES ($1, $2, $3, $4, $5::jsonb)`,
+      [entry.actorId, entry.action, entry.entity, entry.entityId, JSON.stringify(entry.meta ?? {})]
+    );
+  }
+}

--- a/backend/src/auth/authenticate.ts
+++ b/backend/src/auth/authenticate.ts
@@ -1,0 +1,46 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { AppUser } from './user.js';
+
+function parseUserHeader(raw: string | undefined): AppUser | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const tryParse = (value: string): AppUser | undefined => {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed.id === 'string' && Array.isArray(parsed.roles)) {
+        return parsed as AppUser;
+      }
+    } catch (error) {
+      // swallow parsing error and fallback to undefined
+    }
+    return undefined;
+  };
+
+  const fromBase64 = () => {
+    try {
+      const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+      return tryParse(decoded);
+    } catch (error) {
+      return undefined;
+    }
+  };
+
+  return tryParse(trimmed) ?? fromBase64();
+}
+
+export function authenticate() {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const header = req.header('x-user');
+    req.user = parseUserHeader(header);
+    next();
+  };
+}
+
+export type { AppUser } from './user.js';

--- a/backend/src/auth/user.ts
+++ b/backend/src/auth/user.ts
@@ -1,0 +1,11 @@
+export interface AppUser {
+  id: string;
+  roles: string[];
+  orgId?: string | null;
+  permissions?: string[];
+}
+
+export interface RequestScope {
+  orgId?: string | null;
+  programId?: string | null;
+}

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,31 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getPool } from './pool.js';
+
+export async function runMigrations() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const migrationsDir = path.resolve(__dirname, '../../migrations');
+
+  const entries = await fs.readdir(migrationsDir);
+  const files = entries.filter((file) => file.endsWith('.sql')).sort();
+
+  const pool = getPool();
+  for (const file of files) {
+    const sql = await fs.readFile(path.join(migrationsDir, file), 'utf8');
+    await pool.query(sql);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runMigrations()
+    .then(() => {
+      console.log('Migrations applied successfully');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration failure', error);
+      process.exit(1);
+    });
+}

--- a/backend/src/db/pool.ts
+++ b/backend/src/db/pool.ts
@@ -1,0 +1,11 @@
+import { Pool } from 'pg';
+import type { DBClient } from './types.js';
+
+let pool: Pool | null = null;
+
+export function getPool(): DBClient {
+  if (!pool) {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  }
+  return pool;
+}

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -1,0 +1,7 @@
+export interface QueryResult<T> {
+  rows: T[];
+}
+
+export interface DBClient {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<QueryResult<T>>;
+}

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -1,0 +1,15 @@
+import type { ErrorRequestHandler } from 'express';
+import { isAppError } from '../utils/errors.js';
+
+export const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
+  if (isAppError(err)) {
+    return res.status(err.status).json({
+      error: err.code,
+      message: err.message,
+      details: err.details ?? null
+    });
+  }
+
+  console.error('Unhandled error', err);
+  return res.status(500).json({ error: 'internal_server_error' });
+};

--- a/backend/src/middleware/require-auth.ts
+++ b/backend/src/middleware/require-auth.ts
@@ -1,0 +1,8 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  if (!req.user) {
+    return res.status(401).json({ error: 'auth_required' });
+  }
+  return next();
+}

--- a/backend/src/middleware/require-permission.ts
+++ b/backend/src/middleware/require-permission.ts
@@ -1,0 +1,21 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { RequestScope } from '../auth/user.js';
+import { can, type PermissionKey } from '../rbac/policies.js';
+
+export function requirePermission(
+  permission: PermissionKey,
+  resolveScope?: (req: Request) => RequestScope | undefined
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ error: 'auth_required' });
+    }
+
+    const scope = resolveScope ? resolveScope(req) : undefined;
+    if (!can(req.user, permission, scope)) {
+      return res.status(403).json({ error: 'forbidden', permission });
+    }
+
+    return next();
+  };
+}

--- a/backend/src/modules/stakeholders/constants.ts
+++ b/backend/src/modules/stakeholders/constants.ts
@@ -1,0 +1,31 @@
+export const StakeholderTypes = [
+  'referrer',
+  'md',
+  'facility',
+  'payer',
+  'patient_contact',
+  'internal'
+] as const;
+
+export type StakeholderType = (typeof StakeholderTypes)[number];
+
+export const StakeholderStatuses = [
+  'created',
+  'engaged',
+  'active',
+  'dormant',
+  'archived'
+] as const;
+
+export type StakeholderStatus = (typeof StakeholderStatuses)[number];
+
+export const StakeholderMemberRoles = ['owner', 'collaborator', 'viewer'] as const;
+export type StakeholderMemberRole = (typeof StakeholderMemberRoles)[number];
+
+export const allowedStatusTransitions: Record<StakeholderStatus, StakeholderStatus[]> = {
+  created: ['engaged', 'archived'],
+  engaged: ['active', 'dormant', 'archived'],
+  active: ['dormant', 'archived'],
+  dormant: ['active', 'archived'],
+  archived: []
+};

--- a/backend/src/modules/stakeholders/router.ts
+++ b/backend/src/modules/stakeholders/router.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../../middleware/require-auth.js';
+import { requirePermission } from '../../middleware/require-permission.js';
+import { Permissions } from '../../rbac/policies.js';
+import { validateBody } from '../../utils/validate.js';
+import type { StakeholderService } from './service.js';
+import {
+  createStakeholderSchema,
+  updateStakeholderStatusSchema
+} from './validation.js';
+
+export function createStakeholderRouter(deps: { stakeholderService: StakeholderService }) {
+  const router = Router();
+
+  router.post(
+    '/',
+    requireAuth,
+    validateBody(createStakeholderSchema),
+    requirePermission(Permissions.STAKEHOLDER_CREATE, (req) => ({
+      orgId: (req.body as { orgId?: string }).orgId ?? req.user?.orgId ?? null
+    })),
+    async (req, res, next) => {
+      try {
+        const payload = req.body as z.infer<typeof createStakeholderSchema>;
+        const result = await deps.stakeholderService.createStakeholder(payload, req.user!);
+        res.status(201).json(result);
+      } catch (error) {
+        next(error);
+      }
+    }
+  );
+
+  router.patch(
+    '/:id/status',
+    requireAuth,
+    validateBody(updateStakeholderStatusSchema),
+    requirePermission(Permissions.STAKEHOLDER_UPDATE_STATUS, (req) => ({
+      orgId: req.user?.orgId ?? null
+    })),
+    async (req, res, next) => {
+      try {
+        const payload = req.body as z.infer<typeof updateStakeholderStatusSchema>;
+        await deps.stakeholderService.updateStatus(
+          {
+            stakeholderId: req.params.id,
+            status: payload.status,
+            reason: payload.reason
+          },
+          req.user!
+        );
+        res.status(204).send();
+      } catch (error) {
+        next(error);
+      }
+    }
+  );
+
+  return router;
+}

--- a/backend/src/modules/stakeholders/service.ts
+++ b/backend/src/modules/stakeholders/service.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from 'crypto';
+import { AuditService } from '../../audit/service.js';
+import type { AppUser } from '../../auth/user.js';
+import type { DBClient } from '../../db/types.js';
+import { ConflictError, ForbiddenError, NotFoundError } from '../../utils/errors.js';
+import { allowedStatusTransitions } from './constants.js';
+import type {
+  CreateStakeholderInput,
+  StakeholderRecord,
+  UpdateStakeholderStatusInput
+} from './types.js';
+
+type StakeholderStatusRow = Pick<StakeholderRecord, 'id' | 'status' | 'org_id'>;
+
+export class StakeholderService {
+  constructor(private readonly db: DBClient, private readonly audit: AuditService) {}
+
+  async createStakeholder(input: CreateStakeholderInput, actor: AppUser): Promise<{ id: string }> {
+    const id = randomUUID();
+    const orgId = input.orgId ?? actor.orgId ?? null;
+    const ownerId = input.ownerId ?? actor.id;
+    const meta = input.meta ?? {};
+
+    await this.db.query(
+      `INSERT INTO stakeholders (id, type, name, status, owner_id, org_id, meta)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+      [id, input.type, input.name, 'created', ownerId ?? null, orgId, JSON.stringify(meta)]
+    );
+
+    if (ownerId) {
+      await this.db.query(
+        `INSERT INTO stakeholder_members (stakeholder_id, user_id, role)
+         VALUES ($1, $2, 'owner')
+         ON CONFLICT (stakeholder_id, user_id) DO UPDATE SET role = EXCLUDED.role`,
+        [id, ownerId]
+      );
+    }
+
+    await this.audit.log({
+      actorId: actor.id,
+      action: 'stakeholder.created',
+      entity: 'stakeholder',
+      entityId: id,
+      meta: { type: input.type, name: input.name, orgId }
+    });
+
+    return { id };
+  }
+
+  async updateStatus(input: UpdateStakeholderStatusInput, actor: AppUser): Promise<void> {
+    const { stakeholderId, status, reason } = input;
+    const result = await this.db.query<StakeholderStatusRow>(
+      `SELECT id, status, org_id FROM stakeholders WHERE id = $1`,
+      [stakeholderId]
+    );
+
+    if (result.rows.length === 0) {
+      throw new NotFoundError('Stakeholder not found', { stakeholderId });
+    }
+
+    const record = result.rows[0];
+    if (record.org_id && actor.orgId && record.org_id !== actor.orgId) {
+      throw new ForbiddenError('Cross-organization update rejected', {
+        stakeholderOrgId: record.org_id,
+        actorOrgId: actor.orgId
+      });
+    }
+
+    const current = record.status;
+    if (current === status) {
+      return;
+    }
+
+    const allowed = allowedStatusTransitions[current];
+    if (!allowed?.includes(status)) {
+      throw new ConflictError('Status transition not allowed', {
+        from: current,
+        to: status
+      });
+    }
+
+    await this.db.query(
+      `UPDATE stakeholders SET status = $2, updated_at = NOW() WHERE id = $1`,
+      [stakeholderId, status]
+    );
+
+    await this.audit.log({
+      actorId: actor.id,
+      action: 'stakeholder.status_changed',
+      entity: 'stakeholder',
+      entityId: stakeholderId,
+      meta: { from: current, to: status, reason }
+    });
+  }
+}

--- a/backend/src/modules/stakeholders/types.ts
+++ b/backend/src/modules/stakeholders/types.ts
@@ -1,0 +1,27 @@
+import type { StakeholderStatus, StakeholderType } from './constants.js';
+
+export interface StakeholderRecord {
+  id: string;
+  type: StakeholderType;
+  name: string;
+  status: StakeholderStatus;
+  owner_id: string | null;
+  org_id: string | null;
+  meta: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateStakeholderInput {
+  type: StakeholderType;
+  name: string;
+  ownerId?: string;
+  orgId?: string | null;
+  meta?: Record<string, unknown>;
+}
+
+export interface UpdateStakeholderStatusInput {
+  stakeholderId: string;
+  status: StakeholderStatus;
+  reason?: string;
+}

--- a/backend/src/modules/stakeholders/validation.ts
+++ b/backend/src/modules/stakeholders/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { StakeholderStatuses, StakeholderTypes } from './constants.js';
+
+export const createStakeholderSchema = z
+  .object({
+    type: z.enum(StakeholderTypes),
+    name: z.string().min(1),
+    ownerId: z.string().uuid().optional(),
+    orgId: z.string().uuid().optional(),
+    meta: z.record(z.any()).optional()
+  })
+  .strict();
+
+export const updateStakeholderStatusSchema = z
+  .object({
+    status: z.enum(StakeholderStatuses),
+    reason: z.string().min(2).max(280).optional()
+  })
+  .strict();

--- a/backend/src/rbac/policies.ts
+++ b/backend/src/rbac/policies.ts
@@ -1,0 +1,76 @@
+import type { AppUser, RequestScope } from '../auth/user.js';
+
+export const Roles = {
+  ADMIN: 'admin',
+  MANAGER: 'manager',
+  CONTRIBUTOR: 'contributor',
+  VIEWER: 'viewer'
+} as const;
+
+export type RoleKey = (typeof Roles)[keyof typeof Roles];
+
+export const Permissions = {
+  MANAGE_USERS: 'user:manage',
+  STAKEHOLDER_CREATE: 'stakeholder:create',
+  STAKEHOLDER_UPDATE_STATUS: 'stakeholder:update_status',
+  STAKEHOLDER_VIEW: 'stakeholder:view',
+  AUDIT_VIEW: 'audit:view'
+} as const;
+
+export type PermissionKey = (typeof Permissions)[keyof typeof Permissions];
+
+const rolePermissions: Record<RoleKey, PermissionKey[] | ['*']> = {
+  [Roles.ADMIN]: ['*'],
+  [Roles.MANAGER]: [
+    Permissions.STAKEHOLDER_CREATE,
+    Permissions.STAKEHOLDER_UPDATE_STATUS,
+    Permissions.STAKEHOLDER_VIEW,
+    Permissions.AUDIT_VIEW
+  ],
+  [Roles.CONTRIBUTOR]: [Permissions.STAKEHOLDER_CREATE, Permissions.STAKEHOLDER_UPDATE_STATUS, Permissions.STAKEHOLDER_VIEW],
+  [Roles.VIEWER]: [Permissions.STAKEHOLDER_VIEW]
+};
+
+export function resolvePermissionsForRole(role: RoleKey): PermissionKey[] | ['*'] {
+  return rolePermissions[role] ?? [];
+}
+
+function hasOrgScope(user: AppUser, scope?: RequestScope) {
+  if (!scope?.orgId) {
+    return true;
+  }
+  if (!user.orgId) {
+    return false;
+  }
+  return user.orgId === scope.orgId;
+}
+
+export function can(user: AppUser | undefined, permission: PermissionKey, scope?: RequestScope): boolean {
+  if (!user) {
+    return false;
+  }
+
+  if (!hasOrgScope(user, scope)) {
+    return false;
+  }
+
+  const explicit = user.permissions?.includes(permission) || user.permissions?.includes('*');
+  if (explicit) {
+    return true;
+  }
+
+  for (const role of user.roles) {
+    if (!rolePermissions[role as RoleKey]) {
+      continue;
+    }
+    const permissionsForRole = resolvePermissionsForRole(role as RoleKey);
+    if (permissionsForRole[0] === '*') {
+      return true;
+    }
+    if (permissionsForRole.includes(permission)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,18 @@
+import { createApp } from './app.js';
+import { runMigrations } from './db/migrate.js';
+import { getPool } from './db/pool.js';
+
+const port = Number(process.env.PORT ?? 3000);
+
+async function bootstrap() {
+  await runMigrations();
+  const app = createApp({ db: getPool() });
+  app.listen(port, () => {
+    console.log(`Referral Tracker API listening on :${port}`);
+  });
+}
+
+bootstrap().catch((error) => {
+  console.error('Failed to start server', error);
+  process.exit(1);
+});

--- a/backend/src/types/declarations.d.ts
+++ b/backend/src/types/declarations.d.ts
@@ -1,0 +1,80 @@
+declare module 'express' {
+  export interface Request {
+    body?: any;
+    params: Record<string, string>;
+    headers: Record<string, string | string[] | undefined>;
+    user?: import('../auth/user.js').AppUser;
+    header(name: string): string | undefined;
+  }
+
+  export interface Response {
+    status(code: number): Response;
+    json(body: any): Response;
+    send(body?: any): Response;
+  }
+
+  export type NextFunction = (err?: any) => void;
+  export type RequestHandler = (req: Request, res: Response, next: NextFunction) => any;
+  export type ErrorRequestHandler = (err: any, req: Request, res: Response, next: NextFunction) => any;
+
+  export interface Router {
+    use(...handlers: any[]): Router;
+    get(path: string, ...handlers: RequestHandler[]): Router;
+    post(path: string, ...handlers: RequestHandler[]): Router;
+    patch(path: string, ...handlers: RequestHandler[]): Router;
+  }
+
+  export interface Application extends Router {
+    listen(port: number, cb?: () => void): void;
+  }
+
+  export interface ExpressModule {
+    (): Application;
+    Router(): Router;
+    json(options?: any): RequestHandler;
+  }
+
+  const express: ExpressModule;
+  export default express;
+}
+
+declare module 'cors' {
+  import type { RequestHandler } from 'express';
+  export default function cors(options?: any): RequestHandler;
+}
+
+declare module 'pg' {
+  export interface QueryResult<T = any> {
+    rows: T[];
+  }
+
+  export class Pool {
+    constructor(config?: any);
+    query<T = any>(text: string, params?: any[]): Promise<QueryResult<T>>;
+    end(): Promise<void>;
+  }
+}
+
+declare module 'pg-mem' {
+  export interface PgFactory {
+    Pool: {
+      new (): any;
+    };
+  }
+
+  export interface MemoryDb {
+    public: {
+      none(sql: string): void;
+    };
+    adapters: {
+      createPg(): PgFactory;
+    };
+  }
+
+  export function newDb(options?: any): MemoryDb;
+}
+
+declare module 'supertest' {
+  const fn: any;
+  export = fn;
+}

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,7 @@
+import type { AppUser } from '../auth/user';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: AppUser;
+  }
+}

--- a/backend/src/types/jest-globals.d.ts
+++ b/backend/src/types/jest-globals.d.ts
@@ -1,0 +1,5 @@
+declare function describe(name: string, fn: () => void | Promise<void>): void;
+declare function it(name: string, fn: () => void | Promise<void>): void;
+declare function beforeAll(fn: () => void | Promise<void>): void;
+declare function afterAll(fn: () => void | Promise<void>): void;
+declare function expect(actual: any): any;

--- a/backend/src/types/node-globals.d.ts
+++ b/backend/src/types/node-globals.d.ts
@@ -1,0 +1,37 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+  argv: string[];
+  exit(code?: number): never;
+};
+
+declare class BufferClass extends Uint8Array {
+  static from(data: string | ArrayBuffer, encoding?: string): BufferClass;
+  toString(encoding?: string): string;
+}
+
+declare const Buffer: typeof BufferClass;
+
+declare module 'path' {
+  const path: any;
+  export const resolve: (...args: any[]) => string;
+  export const join: (...args: any[]) => string;
+  export const dirname: (input: string) => string;
+  export default path;
+}
+
+declare module 'fs' {
+  export function readFileSync(path: string, options?: any): any;
+}
+
+declare module 'fs/promises' {
+  export function readFile(path: string, options?: any): Promise<any>;
+  export function readdir(path: string): Promise<string[]>;
+}
+
+declare module 'url' {
+  export function fileURLToPath(path: string): string;
+}
+
+declare module 'crypto' {
+  export function randomUUID(): string;
+}

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -1,0 +1,40 @@
+export class AppError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(404, 'not_found', message, details);
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(409, 'conflict', message, details);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(400, 'validation_error', message, details);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(403, 'forbidden', message, details);
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError;
+}

--- a/backend/src/utils/validate.ts
+++ b/backend/src/utils/validate.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from 'express';
+import { z } from 'zod';
+import { ValidationError } from './errors.js';
+
+export function validateBody<T extends z.ZodTypeAny>(schema: T): RequestHandler {
+  return (req, _res, next) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      return next(
+        new ValidationError('Invalid request body', {
+          issues: result.error.issues
+        })
+      );
+    }
+    req.body = result.data;
+    return next();
+  };
+}

--- a/backend/tests/stakeholders.test.ts
+++ b/backend/tests/stakeholders.test.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import request from 'supertest';
+import { newDb } from 'pg-mem';
+import { createApp } from '../src/app.js';
+import type { AppUser } from '../src/auth/user.js';
+import type { DBClient } from '../src/db/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function encodeUser(user: AppUser): string {
+  return Buffer.from(JSON.stringify(user), 'utf8').toString('base64');
+}
+
+describe('Stakeholder API', () => {
+  let app: ReturnType<typeof createApp>;
+  let dbClient: DBClient & { end?: () => Promise<void> };
+
+  beforeAll(async () => {
+    const db = newDb({ autoCreateForeignKeyIndices: true });
+    const migrationSql = fs.readFileSync(path.resolve(__dirname, '../migrations/001_init.sql'), 'utf8');
+    db.public.none(migrationSql);
+
+    const pg = db.adapters.createPg();
+    const pool = new pg.Pool();
+    dbClient = pool as unknown as DBClient & { end?: () => Promise<void> };
+    app = createApp({ db: dbClient });
+
+    await pool.query(
+      `INSERT INTO users (id, email, name, org_id)
+       VALUES
+         ('11111111-1111-1111-1111-111111111111', 'manager@example.com', 'Manager', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+         ('22222222-2222-2222-2222-222222222222', 'viewer@example.com', 'Viewer', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')`
+    );
+  });
+
+  afterAll(async () => {
+    if (dbClient && 'end' in dbClient && typeof dbClient.end === 'function') {
+      await dbClient.end();
+    }
+  });
+
+  it('rejects unauthenticated stakeholder creation', async () => {
+    await request(app)
+      .post('/api/stakeholders')
+      .send({})
+      .expect(401);
+  });
+
+  it('blocks viewer role from creating stakeholders', async () => {
+    const viewer: AppUser = {
+      id: '22222222-2222-2222-2222-222222222222',
+      roles: ['viewer'],
+      orgId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    };
+
+    await request(app)
+      .post('/api/stakeholders')
+      .set('x-user', encodeUser(viewer))
+      .send({
+        type: 'facility',
+        name: 'Viewer Facility'
+      })
+      .expect(403);
+  });
+
+  it('creates stakeholder and records audit trail', async () => {
+    const manager: AppUser = {
+      id: '11111111-1111-1111-1111-111111111111',
+      roles: ['manager'],
+      orgId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    };
+
+    const response = await request(app)
+      .post('/api/stakeholders')
+      .set('x-user', encodeUser(manager))
+      .send({
+        type: 'facility',
+        name: 'Acme Health',
+        meta: { notes: 'Priority lead' }
+      })
+      .expect(201);
+
+    expect(response.body.id).toBeDefined();
+
+    const { rows } = await (dbClient as any).query('SELECT status, meta FROM stakeholders WHERE id = $1', [
+      response.body.id
+    ]);
+    expect(rows[0].status).toBe('created');
+    expect(rows[0].meta.notes).toBe('Priority lead');
+
+    const audit = await (dbClient as any).query(
+      'SELECT action FROM audit_log WHERE entity_id = $1 ORDER BY created_at DESC LIMIT 1',
+      [response.body.id]
+    );
+    expect(audit.rows[0].action).toBe('stakeholder.created');
+  });
+
+  it('allows valid status transitions and audits them', async () => {
+    const manager: AppUser = {
+      id: '11111111-1111-1111-1111-111111111111',
+      roles: ['manager'],
+      orgId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    };
+
+    const createResponse = await request(app)
+      .post('/api/stakeholders')
+      .set('x-user', encodeUser(manager))
+      .send({
+        type: 'referrer',
+        name: 'Cardio Partners'
+      })
+      .expect(201);
+
+    const stakeholderId = createResponse.body.id;
+
+    await request(app)
+      .patch(`/api/stakeholders/${stakeholderId}/status`)
+      .set('x-user', encodeUser(manager))
+      .send({ status: 'engaged', reason: 'Kickoff call scheduled' })
+      .expect(204);
+
+    const { rows } = await (dbClient as any).query('SELECT status FROM stakeholders WHERE id = $1', [
+      stakeholderId
+    ]);
+    expect(rows[0].status).toBe('engaged');
+
+    const audit = await (dbClient as any).query(
+      `SELECT action, meta FROM audit_log WHERE entity_id = $1 ORDER BY created_at DESC LIMIT 1`,
+      [stakeholderId]
+    );
+    expect(audit.rows[0].action).toBe('stakeholder.status_changed');
+    expect(audit.rows[0].meta.to).toBe('engaged');
+  });
+
+  it('rejects invalid status transitions', async () => {
+    const manager: AppUser = {
+      id: '11111111-1111-1111-1111-111111111111',
+      roles: ['manager'],
+      orgId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    };
+
+    const createResponse = await request(app)
+      .post('/api/stakeholders')
+      .set('x-user', encodeUser(manager))
+      .send({
+        type: 'internal',
+        name: 'Field Team'
+      })
+      .expect(201);
+
+    const stakeholderId = createResponse.body.id;
+
+    await request(app)
+      .patch(`/api/stakeholders/${stakeholderId}/status`)
+      .set('x-user', encodeUser(manager))
+      .send({ status: 'active' })
+      .expect(409);
+  });
+
+  it('prevents cross-organization updates', async () => {
+    const otherStakeholderId = '33333333-3333-3333-3333-333333333333';
+    await (dbClient as any).query(
+      `INSERT INTO stakeholders (id, type, name, status, owner_id, org_id, meta)
+       VALUES ($1, 'facility', 'Out of Org', 'engaged', NULL, $2, '{}'::jsonb)`,
+      [otherStakeholderId, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']
+    );
+
+    const manager: AppUser = {
+      id: '11111111-1111-1111-1111-111111111111',
+      roles: ['manager'],
+      orgId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    };
+
+    await request(app)
+      .patch(`/api/stakeholders/${otherStakeholderId}/status`)
+      .set('x-user', encodeUser(manager))
+      .send({ status: 'active' })
+      .expect(403);
+  });
+});

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests", "**/*.test.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
+  "name": "referral-tracker-system",
+  "private": true,
+  "workspaces": ["backend"],
   "scripts": {
-    "format": "prettier -w .",
-    "lint": "eslint .",
-    "test": "jest --runInBand",
-    "build": "tsc -p tsconfig.json || echo 'no build step'"
+    "format": "npm --prefix backend run format",
+    "lint": "npm --prefix backend run lint",
+    "test": "npm --prefix backend run test",
+    "build": "npm --prefix backend run build"
   }
 }


### PR DESCRIPTION
## Summary
- add backend workspace with TypeScript Express API scaffolding
- implement RBAC policies and stakeholder lifecycle services with audit logging
- add SQL migration skeleton, configuration, and tests for stakeholder routes

## Testing
- `npm run lint` *(fails: missing TypeScript/Express typings due to restricted npm registry in environment)*
- `npm run test` *(fails: jest not installed because npm registry access is blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca073542a8832caceb0841c128b89c